### PR TITLE
FHAC-9:Fix Schema for MatchCriterionList matchAlgorithm and minimumDegreeMatch

### DIFF
--- a/src/main/resources/schemas/HL7V3/NE2008/multicacheschemas/PRPA_MT201306UV02.xsd
+++ b/src/main/resources/schemas/HL7V3/NE2008/multicacheschemas/PRPA_MT201306UV02.xsd
@@ -111,8 +111,8 @@ StaticMifToXsd.xsl version 2.0</xs:documentation>
    <xs:complexType name="PRPA_MT201306UV02.MatchAlgorithm">
       <xs:sequence>
          <xs:group ref="InfrastructureRootElements"/>
-         <xs:element name="value" type="ANY" minOccurs="1" maxOccurs="1"/>
-         <xs:element name="semanticsText" type="ST" minOccurs="1" maxOccurs="1"/>
+         <xs:element name="value" type="ST_explicit" minOccurs="1" maxOccurs="1"/>
+         <xs:element name="semanticsText" type="ST_explicit" minOccurs="1" maxOccurs="1"/>
       </xs:sequence>
       <xs:attributeGroup ref="InfrastructureRootAttributes"/>
       <xs:attribute name="nullFlavor" type="NullFlavor" use="optional"/>
@@ -147,8 +147,8 @@ StaticMifToXsd.xsl version 2.0</xs:documentation>
    <xs:complexType name="PRPA_MT201306UV02.MinimumDegreeMatch">
       <xs:sequence>
          <xs:group ref="InfrastructureRootElements"/>
-         <xs:element name="value" type="ANY" minOccurs="1" maxOccurs="1"/>
-         <xs:element name="semanticsText" type="ST" minOccurs="1" maxOccurs="1"/>
+         <xs:element name="value" type="INT" minOccurs="1" maxOccurs="1"/>
+         <xs:element name="semanticsText" type="ST_explicit" minOccurs="1" maxOccurs="1"/>
       </xs:sequence>
       <xs:attributeGroup ref="InfrastructureRootAttributes"/>
       <xs:attribute name="nullFlavor" type="NullFlavor" use="optional"/>


### PR DESCRIPTION
FHAC-9: Fix Schema for MatchAlgorithm and MinimumDegreeMatch in PRPA_MT201306UV02.xsd to accomadate queryByParameter matchCriterionList (HL7 schema).
