### PR TITLE
FHAC-35:Fix PRPA_MT201306UV02.xsd to remove the Restrictions for min and max Integer values of minimumDegreeMatch from schema

### DIFF
--- a/src/main/resources/schemas/HL7V3/NE2008/multicacheschemas/PRPA_MT201306UV02.xsd
+++ b/src/main/resources/schemas/HL7V3/NE2008/multicacheschemas/PRPA_MT201306UV02.xsd
@@ -150,10 +150,7 @@
             <xs:group ref="InfrastructureRootElements"/>
             <xs:element name="value"  minOccurs="1" maxOccurs="1">
                 <xs:simpleType >
-                    <xs:restriction base="xs:integer">
-                        <xs:minInclusive value="0"/>
-                        <xs:maxInclusive value="100"/>
-                    </xs:restriction>
+                    <xs:restriction base="xs:integer"/>
                 </xs:simpleType>
             </xs:element>
             <xs:element name="semanticsText" type="ST_explicit" minOccurs="1" maxOccurs="1"/>


### PR DESCRIPTION
 FHAC-35: Remove schema Restrictions integer values (between 0 and 100) for minimumDegreeMatch from HL7 schema. This is expected to be override by the Adapters implementation.