### PR TITLE
FHAC-118

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <connection>scm:git:git@github.com:${git.username}/Common-Types.git</connection>
         <developerConnection>scm:git:git@github.com:${git.username}/Common-Types.git</developerConnection>
         <url>https://github.com/${git.username}/Common-Types</url>
-      <tag>4.1.0A-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>
@@ -33,7 +33,7 @@
             <url>http://www.connectopensource.org/product/licensing</url>
         </license>
     </licenses>
-    
+
     <dependencies>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
@@ -53,19 +53,20 @@
         </resources>
         <plugins>
             <plugin>
-             <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-release-plugin</artifactId>
-              <version>2.4</version>
-              <configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
                     <pushChanges>false</pushChanges>
-              </configuration>
-          </plugin>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
                 <artifactId>maven-jaxb2-plugin</artifactId>
                 <version>0.8.3</version>
                 <configuration>
                     <generateDirectory>${project.build.directory}/generated-sources/</generateDirectory>
+                    <bindingDirectory>${basedir}/src/main/resources/schemas/</bindingDirectory>
                     <schemaDirectory>${basedir}/src/main/resources/schemas/</schemaDirectory>
                     <strict>${xjc.strict}</strict>
                     <schemaIncludes>
@@ -111,7 +112,7 @@
                 </configuration>
             </plugin>
         </plugins>
-        </build>
+    </build>
     <pluginRepositories>
         <pluginRepository>
             <id>apache-snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,17 @@
         </license>
     </licenses>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
@@ -109,6 +120,14 @@
                     <target>1.6</target>
                     <testSource>1.6</testSource>
                     <testTarget>1.6</testTarget>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!-- use baseVersion instead of unique timestamp version to support skinny WARS -->
+                    <outputFileNameMapping>@{artifactId}@-@{baseVersion}@.@{extension}@</outputFileNameMapping>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/resources/schemas/directconfig.xjb
+++ b/src/main/resources/schemas/directconfig.xjb
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<bindings version="2.1" xmlns="http://java.sun.com/xml/ns/jaxb">
+    <bindings schemaLocation="directConfig/ConfigurationService_schema1.xsd">
+        <schemaBindings>
+            <package name="gov.hhs.fha.nhinc.direct.config" />
+        </schemaBindings>
+    </bindings>
+    <bindings schemaLocation="directConfig/ConfigurationService_schemaException.xsd">
+        <schemaBindings>
+            <package name="gov.hhs.fha.nhinc.direct.config.exception" />
+        </schemaBindings>
+    </bindings>
+</bindings>


### PR DESCRIPTION
Changed Direct Config package space, added back Sonatype snapshot release changes.

Old package space:  org.nhind.config.*
New package spaces:  gov.hhs.fha.nhinc.direct.config.* and gov.hhs.fha.nhinc.direct.config.exception.*