### PR TITLE
FHAC-675: removed TransactionId

### DIFF
--- a/src/main/resources/schemas/nhinc/common/AuditLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditLog.xsd
@@ -163,7 +163,6 @@
             <xsd:element name="RemoteHCID" minOccurs="0" type="xsd:string"/>
             <xsd:element name="RequestMessageId" minOccurs="0" type="xsd:string"/>
             <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string"/>
-            <xsd:element name="TransactionId" minOccurs="0" type="xsd:string"/>
             <xsd:element name="UserId" minOccurs="0" type="xsd:string"/>
         </xsd:sequence>
     </xsd:complexType>
@@ -179,7 +178,6 @@
             <xsd:element name="RemoteHCID" minOccurs="0" type="xsd:string"/>
             <xsd:element name="RequestMessageId" minOccurs="0" type="xsd:string"/>
             <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string"/>
-            <xsd:element name="TransactionId" minOccurs="0" type="xsd:string"/>
             <xsd:element name="UserId" minOccurs="0" type="xsd:string"/>
         </xsd:sequence>
     </xsd:complexType>


### PR DESCRIPTION
Removed TransactionId from LogEventRequestType and LogEventSecureRequestType.
@chris and @alameluchidambaram 