### PR TITLE
FHAC-701: Create AuditQueryLog schema to support AuditQueryLog service

### DIFF
--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -16,17 +16,7 @@
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsRequestType" type="tns:QueryAuditEventsRequestType"/>
     
-    <xsd:complexType name="QueryAuditEventsSecureRequestType">
-        <xsd:sequence>
-            <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
-            <xsd:element name="EventType" minOccurs="0" type="xsd:string" />
-            <xsd:element name="EventOutcomeIndicator" minOccurs="0" type="xsd:integer" />
-            <xsd:element name="EventBeginDate" type="xsd:date" />
-            <xsd:element name="EventEndDate" minOccurs="0" type="xsd:date" />
-            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
-        </xsd:sequence>
-    </xsd:complexType>
-    <xsd:element name="QueryAuditEventsSecureRequestType" type="tns:QueryAuditEventsSecureRequestType"/>
+    <xsd:element name="QueryAuditEventsSecureRequestType" type="tns:QueryAuditEventsRequestType"/>
     
     <xsd:complexType name="QueryAuditEventsResponseType" >
         <xsd:sequence>
@@ -44,21 +34,8 @@
     </xsd:complexType>   
     <xsd:element name="QueryAuditEventsResponseType" type="tns:QueryAuditEventsResponseType"/>
     
-    <xsd:complexType name="QueryAuditEventsSecureResponseType" >
-        <xsd:sequence>
-            <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
-            <xsd:element name="EventType"  type="xsd:string" />
-            <xsd:element name="EventId"  type="xsd:string" />
-            <xsd:element name="EventOutcomeIndicator"  type="xsd:integer" />
-            <xsd:element name="EventTimestamp" type="xsd:dateTime" />
-            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
-            <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string" />
-            <xsd:element name="Direction"  type="xsd:string" />
-            <xsd:element name="Id"  type="xsd:long" />
-            <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
-        </xsd:sequence>
-    </xsd:complexType>   
-    <xsd:element name="QueryAuditEventsSecureResponseType" type="tns:QueryAuditEventsSecureResponseType"/>
+    
+    <xsd:element name="QueryAuditEventsSecureResponseType" type="tns:QueryAuditEventsResponseType"/>
     
     <xsd:complexType name="QueryAuditEventsRequestByRequestMessageId">
         <xsd:sequence>
@@ -67,12 +44,8 @@
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
     
-    <xsd:complexType name="QueryAuditEventsSecureRequestByRequestMessageId">
-        <xsd:sequence>
-            <xsd:element name="RequestMessageId" type="xsd:string" />
-        </xsd:sequence>
-    </xsd:complexType>
-    <xsd:element name="QueryAuditEventsSecureRequestByRequestMessageId" type="tns:QueryAuditEventsSecureRequestByRequestMessageId"/>
+    
+    <xsd:element name="QueryAuditEventsSecureRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
     
     <xsd:complexType name="QueryAuditEventsBlobRequest" >
         <xsd:sequence>
@@ -81,12 +54,8 @@
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsBlobRequest" type="tns:QueryAuditEventsBlobRequest"/>
     
-    <xsd:complexType name="QueryAuditEventsBlobSecureRequest" >
-        <xsd:sequence>
-            <xsd:element name="Id" type="xsd:long" />
-        </xsd:sequence>
-    </xsd:complexType>
-    <xsd:element name="QueryAuditEventsBlobSecureRequest" type="tns:QueryAuditEventsBlobSecureRequest"/>
+    
+    <xsd:element name="QueryAuditEventsBlobSecureRequest" type="tns:QueryAuditEventsBlobRequest"/>
     
     <xsd:complexType name="QueryAuditEventsBlobResponse" >
         <xsd:sequence>
@@ -95,10 +64,6 @@
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsBlobResponse" type="tns:QueryAuditEventsBlobResponse"/>
     
-    <xsd:complexType name="QueryAuditEventsBlobSecureResponse" >
-        <xsd:sequence>
-            <xsd:element ref="adtmsg:AuditMessage" />
-        </xsd:sequence>
-    </xsd:complexType>
-    <xsd:element name="QueryAuditEventsBlobSecureResponse" type="tns:QueryAuditEventsBlobSecureResponse"/>
+    
+    <xsd:element name="QueryAuditEventsBlobSecureResponse" type="tns:QueryAuditEventsBlobResponse"/>
 </xsd:schema>

--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -9,12 +9,25 @@
             <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
             <xsd:element name="EventType" minOccurs="0" type="xsd:string" />
             <xsd:element name="EventOutcomeIndicator" minOccurs="0" type="xsd:integer" />
-            <xsd:element name="eventBeginDateTime" type="xsd:dateTime" />
-            <xsd:element name="eventEndDateTime" minOccurs="0" type="xsd:dateTime" />
+            <xsd:element name="EventBeginDate" type="xsd:date" />
+            <xsd:element name="EventEndDate" minOccurs="0" type="xsd:date" />
             <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsRequestType" type="tns:QueryAuditEventsRequestType"/>
+    
+    <xsd:complexType name="QueryAuditEventsSecureRequestType">
+        <xsd:sequence>
+            <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
+            <xsd:element name="EventType" minOccurs="0" type="xsd:string" />
+            <xsd:element name="EventOutcomeIndicator" minOccurs="0" type="xsd:integer" />
+            <xsd:element name="EventBeginDate" type="xsd:date" />
+            <xsd:element name="EventEndDate" minOccurs="0" type="xsd:date" />
+            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsSecureRequestType" type="tns:QueryAuditEventsRequestType"/>
+    
     <xsd:complexType name="QueryAuditEventsResponseType" >
         <xsd:sequence>
             <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
@@ -28,8 +41,25 @@
             <xsd:element name="Id"  type="xsd:long" />
             <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
         </xsd:sequence>
-    </xsd:complexType>
+    </xsd:complexType>   
     <xsd:element name="QueryAuditEventsResponseType" type="tns:QueryAuditEventsResponseType"/>
+    
+    <xsd:complexType name="QueryAuditEventsSecureResponseType" >
+        <xsd:sequence>
+            <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
+            <xsd:element name="EventType"  type="xsd:string" />
+            <xsd:element name="EventId"  type="xsd:string" />
+            <xsd:element name="EventOutcomeIndicator"  type="xsd:integer" />
+            <xsd:element name="EventTimestamp" type="xsd:dateTime" />
+            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
+            <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string" />
+            <xsd:element name="Direction"  type="xsd:string" />
+            <xsd:element name="Id"  type="xsd:long" />
+            <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>   
+    <xsd:element name="QueryAuditEventsSecureResponseType" type="tns:QueryAuditEventsResponseType"/>
+    
     <xsd:complexType name="QueryAuditEventsRequestByRequestMessageId">
         <xsd:sequence>
             <xsd:element name="RequestMessageId" type="xsd:string" />
@@ -37,16 +67,38 @@
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
     
+    <xsd:complexType name="QueryAuditEventsSecureRequestByRequestMessageId">
+        <xsd:sequence>
+            <xsd:element name="RequestMessageId" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsSecureRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
+    
     <xsd:complexType name="QueryAuditEventsBlobRequest" >
         <xsd:sequence>
             <xsd:element name="Id" type="xsd:long" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsBlobRequest" type="tns:QueryAuditEventsBlobRequest"/>
+    
+    <xsd:complexType name="QueryAuditEventsBlobSecureRequest" >
+        <xsd:sequence>
+            <xsd:element name="Id" type="xsd:long" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsBlobSecureRequest" type="tns:QueryAuditEventsBlobRequest"/>
+    
     <xsd:complexType name="QueryAuditEventsBlobResponse" >
         <xsd:sequence>
             <xsd:element ref="adtmsg:AuditMessage" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsBlobResponse" type="tns:QueryAuditEventsBlobResponse"/>
+    
+    <xsd:complexType name="QueryAuditEventsBlobSecureResponse" >
+        <xsd:sequence>
+            <xsd:element ref="adtmsg:AuditMessage" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsBlobSecureResponse" type="tns:QueryAuditEventsBlobResponse"/>
 </xsd:schema>

--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -4,24 +4,41 @@
             xmlns:tns="urn:gov:hhs:fha:nhinc:common:auditquerylog"
             xmlns:adtmsg="http://nhinc.services.com/schema/auditmessage">
     <xsd:import schemaLocation="../../../schemas/ihe/auditmessage.xsd" namespace="http://nhinc.services.com/schema/auditmessage"/>
+
+    <!--Adopter can search for multiple events-->
+    <xsd:complexType name="EventTypeList">
+        <xsd:sequence>
+            <xsd:element name="EventType" minOccurs="0" maxOccurs="unbounded" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="EventTypeList" type="tns:EventTypeList"/>
+
+    <!--Adopter can search for multiple communities-->
+    <xsd:complexType name="RemoteHcidList">
+        <xsd:sequence>
+            <xsd:element name="RemoteHcid" minOccurs="0" maxOccurs="unbounded" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="RemoteHcidList" type="tns:RemoteHcidList"/>
+
     <xsd:complexType name="QueryAuditEventsRequestType">
         <xsd:sequence>
             <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
-            <xsd:element name="EventType" minOccurs="0" type="xsd:string" />
+            <xsd:element name="EventTypeList" minOccurs="0" type="tns:EventTypeList"/>
             <xsd:element name="EventOutcomeIndicator" minOccurs="0" type="xsd:integer" />
             <xsd:element name="EventBeginDate" type="xsd:date" />
             <xsd:element name="EventEndDate" minOccurs="0" type="xsd:date" />
-            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
+            <xsd:element name="RemoteHcidList" minOccurs="0" type="tns:RemoteHcidList" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsRequestType" type="tns:QueryAuditEventsRequestType"/>
-    
+
     <xsd:element name="QueryAuditEventsSecureRequestType" type="tns:QueryAuditEventsRequestType"/>
-    
-    <xsd:complexType name="QueryAuditEventsResponseType" >
+
+    <xsd:complexType name="QueryAuditEventsResults">
         <xsd:sequence>
             <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
-            <xsd:element name="EventType"  type="xsd:string" />
+            <xsd:element name="EventType" minOccurs="0" type="xsd:string"/>
             <xsd:element name="EventId"  type="xsd:string" />
             <xsd:element name="EventOutcomeIndicator"  type="xsd:integer" />
             <xsd:element name="EventTimestamp" type="xsd:dateTime" />
@@ -31,39 +48,47 @@
             <xsd:element name="Id"  type="xsd:long" />
             <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
         </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsResults" type="tns:QueryAuditEventsResults"/>    
+
+    <xsd:complexType name="QueryAuditEventsResponseType" >
+        <xsd:sequence>
+            <xsd:element name="QueryAuditEventsResults" minOccurs="0" maxOccurs="unbounded" type="tns:QueryAuditEventsResults"/> 
+        </xsd:sequence>
     </xsd:complexType>   
     <xsd:element name="QueryAuditEventsResponseType" type="tns:QueryAuditEventsResponseType"/>
-    
-    
+
+
     <xsd:element name="QueryAuditEventsSecureResponseType" type="tns:QueryAuditEventsResponseType"/>
-    
+
     <xsd:complexType name="QueryAuditEventsRequestByRequestMessageId">
         <xsd:sequence>
-            <xsd:element name="RequestMessageId" type="xsd:string" />
+            <xsd:element name="RequestMessageId" minOccurs="0" type="xsd:string" />
+            <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
-    
-    
+
+
     <xsd:element name="QueryAuditEventsSecureRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
-    
+
     <xsd:complexType name="QueryAuditEventsBlobRequest" >
         <xsd:sequence>
             <xsd:element name="Id" type="xsd:long" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsBlobRequest" type="tns:QueryAuditEventsBlobRequest"/>
-    
-    
+
+
     <xsd:element name="QueryAuditEventsBlobSecureRequest" type="tns:QueryAuditEventsBlobRequest"/>
-    
+
     <xsd:complexType name="QueryAuditEventsBlobResponse" >
         <xsd:sequence>
             <xsd:element ref="adtmsg:AuditMessage" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsBlobResponse" type="tns:QueryAuditEventsBlobResponse"/>
-    
-    
+
+
     <xsd:element name="QueryAuditEventsBlobSecureResponse" type="tns:QueryAuditEventsBlobResponse"/>
 </xsd:schema>

--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -32,31 +32,14 @@
     <xsd:element name="QueryAuditEventsResponseType" type="tns:QueryAuditEventsResponseType"/>
     <xsd:complexType name="QueryAuditEventsRequestByRequestMessageId">
         <xsd:sequence>
-            <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
+            <xsd:element name="RequestMessageId" type="xsd:string" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
     
-    <xsd:complexType name="QueryAuditEventsResponseByRequestMessageId" >
-        <xsd:sequence>
-            <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
-            <xsd:element name="EventType"  type="xsd:string" />
-            <xsd:element name="EventId"  type="xsd:string" />
-            <xsd:element name="EventOutcomeIndicator"  type="xsd:integer" />
-            <xsd:element name="EventTimestamp" type="xsd:dateTime" />
-            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
-            <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string" />
-            <xsd:element name="Direction"  type="xsd:string" />
-            <xsd:element name="Id"  type="xsd:long" />
-            <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
-        </xsd:sequence>
-    </xsd:complexType>
-    <xsd:element name="QueryAuditEventsResponseByRequestMessageId" type="tns:QueryAuditEventsResponseByRequestMessageId"/>
-    
     <xsd:complexType name="QueryAuditEventsBlobRequest" >
         <xsd:sequence>
             <xsd:element name="Id" type="xsd:long" />
-            <xsd:element ref="adtmsg:AuditMessage" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsBlobRequest" type="tns:QueryAuditEventsBlobRequest"/>

--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:gov:hhs:fha:nhinc:common:auditquerylog"
+            xmlns:tns="urn:gov:hhs:fha:nhinc:common:auditquerylog"
+            xmlns:adtmsg="http://nhinc.services.com/schema/auditmessage">
+    <xsd:import schemaLocation="../../../schemas/ihe/auditmessage.xsd" namespace="http://nhinc.services.com/schema/auditmessage"/>
+    <xsd:complexType name="QueryAuditEventsRequestType">
+        <xsd:sequence>
+            <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
+            <xsd:element name="EventType" minOccurs="0" type="xsd:string" />
+            <xsd:element name="EventOutcomeIndicator" minOccurs="0" type="xsd:integer" />
+            <xsd:element name="eventBeginDateTime" type="xsd:dateTime" />
+            <xsd:element name="eventEndDateTime" minOccurs="0" type="xsd:dateTime" />
+            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsRequestType" type="tns:QueryAuditEventsRequestType"/>
+    <xsd:complexType name="QueryAuditEventsResponseType" >
+        <xsd:sequence>
+            <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
+            <xsd:element name="EventType"  type="xsd:string" />
+            <xsd:element name="EventId"  type="xsd:string" />
+            <xsd:element name="EventOutcomeIndicator"  type="xsd:integer" />
+            <xsd:element name="EventTimestamp" type="xsd:dateTime" />
+            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
+            <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string" />
+            <xsd:element name="Direction"  type="xsd:string" />
+            <xsd:element name="Id"  type="xsd:long" />
+            <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsResponseType" type="tns:QueryAuditEventsResponseType"/>
+    <xsd:complexType name="QueryAuditEventsRequestByRequestMessageId">
+        <xsd:sequence>
+            <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
+    
+    <xsd:complexType name="QueryAuditEventsResponseByRequestMessageId" >
+        <xsd:sequence>
+            <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
+            <xsd:element name="EventType"  type="xsd:string" />
+            <xsd:element name="EventId"  type="xsd:string" />
+            <xsd:element name="EventOutcomeIndicator"  type="xsd:integer" />
+            <xsd:element name="EventTimestamp" type="xsd:dateTime" />
+            <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
+            <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string" />
+            <xsd:element name="Direction"  type="xsd:string" />
+            <xsd:element name="Id"  type="xsd:long" />
+            <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsResponseByRequestMessageId" type="tns:QueryAuditEventsResponseByRequestMessageId"/>
+    
+    <xsd:complexType name="QueryAuditEventsBlobRequest" >
+        <xsd:sequence>
+            <xsd:element name="Id" type="xsd:long" />
+            <xsd:element ref="adtmsg:AuditMessage" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsBlobRequest" type="tns:QueryAuditEventsBlobRequest"/>
+    <xsd:complexType name="QueryAuditEventsBlobResponse" >
+        <xsd:sequence>
+            <xsd:element ref="adtmsg:AuditMessage" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="QueryAuditEventsBlobResponse" type="tns:QueryAuditEventsBlobResponse"/>
+</xsd:schema>

--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -26,7 +26,7 @@
             <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
         </xsd:sequence>
     </xsd:complexType>
-    <xsd:element name="QueryAuditEventsSecureRequestType" type="tns:QueryAuditEventsRequestType"/>
+    <xsd:element name="QueryAuditEventsSecureRequestType" type="tns:QueryAuditEventsSecureRequestType"/>
     
     <xsd:complexType name="QueryAuditEventsResponseType" >
         <xsd:sequence>
@@ -58,7 +58,7 @@
             <xsd:element name="RequestMessageId"  minOccurs="0" type="xsd:string" />
         </xsd:sequence>
     </xsd:complexType>   
-    <xsd:element name="QueryAuditEventsSecureResponseType" type="tns:QueryAuditEventsResponseType"/>
+    <xsd:element name="QueryAuditEventsSecureResponseType" type="tns:QueryAuditEventsSecureResponseType"/>
     
     <xsd:complexType name="QueryAuditEventsRequestByRequestMessageId">
         <xsd:sequence>
@@ -72,7 +72,7 @@
             <xsd:element name="RequestMessageId" type="xsd:string" />
         </xsd:sequence>
     </xsd:complexType>
-    <xsd:element name="QueryAuditEventsSecureRequestByRequestMessageId" type="tns:QueryAuditEventsRequestByRequestMessageId"/>
+    <xsd:element name="QueryAuditEventsSecureRequestByRequestMessageId" type="tns:QueryAuditEventsSecureRequestByRequestMessageId"/>
     
     <xsd:complexType name="QueryAuditEventsBlobRequest" >
         <xsd:sequence>
@@ -86,7 +86,7 @@
             <xsd:element name="Id" type="xsd:long" />
         </xsd:sequence>
     </xsd:complexType>
-    <xsd:element name="QueryAuditEventsBlobSecureRequest" type="tns:QueryAuditEventsBlobRequest"/>
+    <xsd:element name="QueryAuditEventsBlobSecureRequest" type="tns:QueryAuditEventsBlobSecureRequest"/>
     
     <xsd:complexType name="QueryAuditEventsBlobResponse" >
         <xsd:sequence>
@@ -100,5 +100,5 @@
             <xsd:element ref="adtmsg:AuditMessage" />
         </xsd:sequence>
     </xsd:complexType>
-    <xsd:element name="QueryAuditEventsBlobSecureResponse" type="tns:QueryAuditEventsBlobResponse"/>
+    <xsd:element name="QueryAuditEventsBlobSecureResponse" type="tns:QueryAuditEventsBlobSecureResponse"/>
 </xsd:schema>

--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -26,7 +26,7 @@
             <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
             <xsd:element name="EventTypeList" minOccurs="0" type="tns:EventTypeList"/>
             <xsd:element name="EventOutcomeIndicator" minOccurs="0" type="xsd:integer" />
-            <xsd:element name="EventBeginDate" type="xsd:date" />
+            <xsd:element name="EventBeginDate" minOccurs="0" type="xsd:date" />
             <xsd:element name="EventEndDate" minOccurs="0" type="xsd:date" />
             <xsd:element name="RemoteHcidList" minOccurs="0" type="tns:RemoteHcidList" />
         </xsd:sequence>


### PR DESCRIPTION
1. Create XSD to support AuditQueryLog service to query audit events from System Administration Module  in 3 different ways.