### PR TITLE
FHAC-690:Fix schema to accept empty Blob Response

### DIFF
--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -84,7 +84,7 @@
 
     <xsd:complexType name="QueryAuditEventsBlobResponse" >
         <xsd:sequence>
-            <xsd:element ref="adtmsg:AuditMessage" />
+            <xsd:element minOccurs="0" ref="adtmsg:AuditMessage" />
         </xsd:sequence>
     </xsd:complexType>
     <xsd:element name="QueryAuditEventsBlobResponse" type="tns:QueryAuditEventsBlobResponse"/>


### PR DESCRIPTION
Fix Schema to accept empty Blob Response in case of Blob not available in db