### PR TITLE
FHAC-894: remove EventOutcomeIndicator field

### DIFF
--- a/src/main/resources/schemas/nhinc/common/AuditLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditLog.xsd
@@ -159,7 +159,6 @@
             <xsd:element name="EventTimestamp" maxOccurs="1" type="xsd:dateTime"/>
             <xsd:element name="EventID" maxOccurs="1" type="xsd:string"/>
             <xsd:element name="EventType" maxOccurs="1" type="xsd:string"/>
-            <xsd:element name="EventOutcomeIndicator" maxOccurs="1" type="xsd:integer"/>
             <xsd:element name="RemoteHCID" minOccurs="0" type="xsd:string"/>
             <xsd:element name="RequestMessageId" minOccurs="0" type="xsd:string"/>
             <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string"/>
@@ -174,7 +173,6 @@
             <xsd:element name="EventTimestamp" maxOccurs="1" type="xsd:dateTime"/>
             <xsd:element name="EventID" maxOccurs="1" type="xsd:string"/>
             <xsd:element name="EventType" maxOccurs="1" type="xsd:string"/>
-            <xsd:element name="EventOutcomeIndicator" maxOccurs="1" type="xsd:integer"/>
             <xsd:element name="RemoteHCID" minOccurs="0" type="xsd:string"/>
             <xsd:element name="RequestMessageId" minOccurs="0" type="xsd:string"/>
             <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string"/>

--- a/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
+++ b/src/main/resources/schemas/nhinc/common/AuditQueryLog.xsd
@@ -26,7 +26,6 @@
         <xsd:sequence>
             <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
             <xsd:element name="EventTypeList" minOccurs="0" type="tns:EventTypeList"/>
-            <xsd:element name="EventOutcomeIndicator" minOccurs="0" type="xsd:integer" />
             <xsd:element name="EventBeginDate" minOccurs="0" type="xsd:dateTime" />
             <xsd:element name="EventEndDate" minOccurs="0" type="xsd:dateTime" />
             <xsd:element name="RemoteHcidList" minOccurs="0" type="tns:RemoteHcidList" />
@@ -41,7 +40,6 @@
             <xsd:element name="UserId" minOccurs="0" type="xsd:string" />
             <xsd:element name="EventType" minOccurs="0" type="xsd:string"/>
             <xsd:element name="EventId"  type="xsd:string" />
-            <xsd:element name="EventOutcomeIndicator"  type="xsd:integer" />
             <xsd:element name="EventTimestamp" type="xsd:dateTime" />
             <xsd:element name="RemoteHcid" minOccurs="0" type="xsd:string" />
             <xsd:element name="RelatesTo" minOccurs="0" type="xsd:string" />


### PR DESCRIPTION
Remove EventOutcomeIndicator since it is unused.
@TabassumJafri @sailajaa Can you please review?